### PR TITLE
create "dojos"-rootfolder, if it does not exist

### DIFF
--- a/app/models/dojo.rb
+++ b/app/models/dojo.rb
@@ -29,6 +29,10 @@ class Dojo
     inner = root_folder + '/' + Dojo::inner_folder(name)
     outer = inner + '/' + Dojo::outer_folder(name)
     
+    if !File.directory? root_folder
+      make_dir(root_folder)
+    end
+
     io_lock(root_folder) do
       if File.directory? inner and File.directory? outer
         false


### PR DESCRIPTION
Hi, 

when you get CyberDojo by git, it does not create the "dojos" empty directory. This leads to an error when trying to create a dojo and the directory has to be hand-created.

This simple patch checks for the existence of the dojos-directory and creates it if it does not exist.

Best Regards,
Aleksi Aalto (from Jorvas)
