### PR TITLE
CoffeeScript support

### DIFF
--- a/app/helpers/run_tests_output_parser_helper.rb
+++ b/app/helpers/run_tests_output_parser_helper.rb
@@ -157,6 +157,15 @@ module RunTestsOutputParserHelper
     end
   end
 
+  def parse_jasmine(output)
+     jasmine_pattern = /(\d+) test, (\d+) assertion, (\d+) failure/
+     if jasmine_pattern.match(output)
+        return $3 == "0" ? :passed : :failed
+     else
+        :error
+     end
+  end
+
 end
 
 

--- a/filesets/language/CoffeeScript/cyberdojo.sh
+++ b/filesets/language/CoffeeScript/cyberdojo.sh
@@ -1,0 +1,1 @@
+jasmine-node --coffee --noColor .

--- a/filesets/language/CoffeeScript/manifest.rb
+++ b/filesets/language/CoffeeScript/manifest.rb
@@ -1,0 +1,9 @@
+
+{
+  :visible_filenames => %w( untitled.coffee untitled_spec.coffee cyberdojo.sh ),
+
+  :unit_test_framework => 'jasmine',
+
+  :tab_size => 2
+}
+

--- a/filesets/language/CoffeeScript/untitled.coffee
+++ b/filesets/language/CoffeeScript/untitled.coffee
@@ -1,0 +1,5 @@
+class exports.Untitled
+
+  answer: () ->
+    8*7
+

--- a/filesets/language/CoffeeScript/untitled_spec.coffee
+++ b/filesets/language/CoffeeScript/untitled_spec.coffee
@@ -1,0 +1,9 @@
+imports = require './untitled'
+
+describe 'jasmine-node', ->
+
+  it 'should pass', ->
+    untitled = new imports.Untitled()
+    expect(untitled.answer()).toEqual 42
+
+


### PR DESCRIPTION
This adds CoffeeScript support with Jasmine to CyberDojo

What I did to install Node.JS, CoffeeScript and Jasmine:
- Download node.js from http://nodejs.org/ (http://nodejs.org/dist/v0.6.6/node-v0.6.6.tar.gz)
- ./configure; make; make install
- (The rest is a hack because of my imperfect understanding of npm)
- npm install jasmine-node
- mv ...../node_modules/jasmine-node /usr/local/lib/node_modules
- ln -s /usr/local/lib/node_modules/jasmine-node/bin/jasmine-node /usr/local/bin
