### PR TITLE
Add Haskell language support to Cyberdojo

### DIFF
--- a/app/helpers/run_tests_output_parser_helper.rb
+++ b/app/helpers/run_tests_output_parser_helper.rb
@@ -181,6 +181,20 @@ module RunTestsOutputParserHelper
      end
   end
 
-end
+  def parse_hunit(output)
+    puts output
+    if output =~ /Counts \{cases = (\d+), tried = (\d+), errors = (\d+), failures = (\d+)\}/
+      if $3.to_i != 0
+        :error
+      elsif $4.to_i != 0
+        :failed
+      else
+        :passed
+      end
+    else
+      :error
+    end
+  end
 
+end
 

--- a/filesets/language/Haskell/Untitled.hs
+++ b/filesets/language/Haskell/Untitled.hs
@@ -1,0 +1,4 @@
+module Untitled where
+
+answer = 42
+

--- a/filesets/language/Haskell/cyberdojo.sh
+++ b/filesets/language/Haskell/cyberdojo.sh
@@ -1,0 +1,1 @@
+runhaskell *test*.hs

--- a/filesets/language/Haskell/manifest.rb
+++ b/filesets/language/Haskell/manifest.rb
@@ -1,0 +1,8 @@
+{
+  :visible_filenames => %w( Untitled.hs test_Untitled.hs cyberdojo.sh ),
+
+  :unit_test_framework => 'hunit',
+
+  :tab_size => 4
+}
+

--- a/filesets/language/Haskell/test_Untitled.hs
+++ b/filesets/language/Haskell/test_Untitled.hs
@@ -1,0 +1,9 @@
+module Test_Untitled where
+
+import Test.HUnit
+import Untitled
+
+answer_test = TestCase (assertEqual "Testing answer" (6 * 9) answer)
+
+tests = TestList [answer_test]
+main = do runTestTT tests

--- a/test/functional/language_fileset_tests.rb
+++ b/test/functional/language_fileset_tests.rb
@@ -26,6 +26,7 @@ class LanguageFileSetTests < ActionController::TestCase
     'C#' => 'Untitled.cs',
     'C++' => 'untitled.cpp',
     'Erlang' => 'untitled.erl',
+    'Haskell' => 'Untitled.hs',
     'Java' => 'Untitled.java',
     'Javascript' => 'untitled.js',
     'Perl' => 'untitled.perl',


### PR DESCRIPTION
Adds all necessary files and changes for Haskell support. The HUnit library is used for unit testing.
Also, adding the Haskell compiler and the unit testing library to Ubuntu requires the following packages to be installed:
sudo apt-get install ghc
sudo apt-get install libghc6-hunit-dev
