### PR TITLE
Fix poker hands exercise instructions

### DIFF
--- a/filesets/exercise/Poker Hands/instructions
+++ b/filesets/exercise/Poker Hands/instructions
@@ -60,7 +60,7 @@ Input: Black: 2H 3D 5S 9C KD White: 2C 3H 4S 8C AH
 Output: White wins - high card: Ace 
 
 Input: Black: 2H 4S 4C 2D 4H White: 2S 8S AS QS 3S
-Output: White wins - flush 
+Output: Black wins - full house
 
 Input: Black: 2H 3D 5S 9C KD White: 2C 3H 4S 8C KH
 Output: Black wins - high card: 9


### PR DESCRIPTION
Hi,

I stumbled upon the following mistake while coding the poker hands exercise.

Regards,
Miika

```
One example case in pokerhands exercise states that a poker hand
"2S 8S AS QS 3S" wins over poker hand "2H 4S 4C 2D 4H". This is, however,
a mistake as the first-mentioned hand is a full house and the latter
is a flush. A full house wins always over a flush as per instructions.
```
