### PR TITLE
CoffeeScript output error, amber on all tests passed.

### DIFF
--- a/lib/CodeOutputParser.rb
+++ b/lib/CodeOutputParser.rb
@@ -167,7 +167,7 @@ module CodeOutputParser
   end
 
   def self.parse_jasmine(output)
-     jasmine_pattern = /(\d+) test[s], (\d+) assertion[s], (\d+) failure[s]/
+     jasmine_pattern = /(\d+) tests?, (\d+) assertions?, (\d+) failures?/
      if jasmine_pattern.match(output)
         return $3 == "0" ? :green : :red
      else


### PR DESCRIPTION
I've updated the CodeOutputParser.rb file so that when testing CoffeeScript code with Jasmine-node the regex will now correctly identify multiple tests passed as a green light situation.
