### PR TITLE
ensure the output is valid before parsing

### DIFF
--- a/app/models/sandbox.rb
+++ b/app/models/sandbox.rb
@@ -29,7 +29,7 @@ class Sandbox
     make_dir
     output = inner_run(language, visible_files)
     system("rm -rf #{dir}")
-    output
+    output.encode('utf-8', 'binary', :invalid => :replace, :undef => :replace)
   end
   
   def inner_run(language, visible_files)


### PR DESCRIPTION
sometimes output from the test run can have
invalid encoding (such as binary output),
with invalid encoding parsing raises Exception
which stops further processing(such as save
or diff)

now it ensures the captured output has valid
bytes for UTF-8 encoding.
