### PR TITLE
Retain line numbers when you run the tests

### DIFF
--- a/app/views/kata/_test_button.html.erb
+++ b/app/views/kata/_test_button.html.erb
@@ -24,6 +24,7 @@ $(document).ready(function() {
     test.attr('disabled', false);
     $('#tip').hide();
     cd.rebuildFilenameList();
+    cd.bindAllLineNumbers();
     // when the ajax replaces output the shortcuts
     // are lost so need rebinding
     var output = cd.fileContentFor('output');

--- a/app/views/kata/run_tests.js.erb
+++ b/app/views/kata/run_tests.js.erb
@@ -5,6 +5,5 @@ $("#current_traffic_light_count")
 $("#traffic_lights")
   .html("<%= js_partial('traffic_lights') %>");
 
-$("#output")
-  .html("<%= js_partial('output') %>");
-
+$("#visible_files_container")
+  .html("<%= js_partial('editor') %>");


### PR DESCRIPTION
I think this commit fixes the problem with the line numbers being lost when you press "test".
