### PR TITLE
Fix for docker setup script

### DIFF
--- a/admin_scripts/setup_docker_server.sh
+++ b/admin_scripts/setup_docker_server.sh
@@ -16,9 +16,9 @@ cd /etc/apache2/sites-enabled
 ln -s ../sites-available/cyberdojo cyberdojo
 rm railsapp
 cd /etc/apache2/conf
-sed s/railsapp/cyberdojo/ <railsapp.conf >cyberdojo.conf
+sed s/railsapp/cyber-dojo/ <railsapp.conf >cyberdojo.conf
 rm railsapp.conf
-cd /var/www/cyberdojo/admin_scripts
+cd /var/www/cyber-dojo/admin_scripts
 ./pull.sh
 echo "deb http://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
 wget -qO- https://get.docker.io/gpg | apt-key add -


### PR DESCRIPTION
Hi Jon,

I changed the setup_docker_server.sh script to use the new 'cyber-dojo' directory name when I was testing some changes for our sub-domain and thought you might like the fix.

Byran
