### PR TITLE
Fix repeated make

### DIFF
--- a/languages/C++-Boost.Test/makefile
+++ b/languages/C++-Boost.Test/makefile
@@ -5,6 +5,7 @@ HPP_FILES = $(wildcard *.hpp)
 COMPILED_HPP_FILES = $(patsubst %.hpp,%.compiled_hpp,$(HPP_FILES))
 CPP_FILES = $(wildcard *.cpp)
 
+.PHONY: test.output
 test.output: test makefile
 	./$<
 

--- a/languages/C++-Boost.Test/makefile
+++ b/languages/C++-Boost.Test/makefile
@@ -5,9 +5,11 @@ HPP_FILES = $(wildcard *.hpp)
 COMPILED_HPP_FILES = $(patsubst %.hpp,%.compiled_hpp,$(HPP_FILES))
 CPP_FILES = $(wildcard *.cpp)
 
+test.output: test makefile
+	./$<
+
 test: makefile $(CPP_FILES) $(COMPILED_HPP_FILES)
 	$(CXX) -I. $(CXXFLAGS) -O $(CPP_FILES) $(BOOST_LIB) -o $@
-	./$@
 
 # This rule ensures header files build in their own right.
 # The quality of header files is important because header files

--- a/languages/C++-Catch/makefile
+++ b/languages/C++-Catch/makefile
@@ -4,9 +4,12 @@ HPP_FILES = $(wildcard *.hpp)
 COMPILED_HPP_FILES = $(patsubst %.hpp,%.compiled_hpp,$(HPP_FILES))
 CPP_FILES = $(wildcard *.cpp)
 
+.PHONY: test.output
+test.output: test makefile
+	./$<
+
 test: makefile $(CPP_FILES) $(COMPILED_HPP_FILES)
 	@$(CXX) -I. $(CXXFLAGS) -O $(CPP_FILES) -o $@
-	@./$@
 
 # don't compile catch.hpp header
 catch.compiled_hpp: catch.hpp

--- a/languages/C++-GoogleTest/makefile
+++ b/languages/C++-GoogleTest/makefile
@@ -5,9 +5,12 @@ HPP_FILES = $(wildcard *.hpp)
 COMPILED_HPP_FILES = $(patsubst %.hpp,%.compiled_hpp,$(HPP_FILES))
 CPP_FILES = $(wildcard *.cpp)
 
+.PHONY: test.output
+test.output: test makefile
+	./$< --gtest_shuffle
+
 test: makefile $(CPP_FILES) $(COMPILED_HPP_FILES)
 	$(CXX) -I. $(CXXFLAGS) -O $(CPP_FILES) $(GTEST_LIBS) -o $@
-	./$@ --gtest_shuffle
 
 # This rule ensures header files build in their own right.
 # The quality of header files is important because header files

--- a/languages/C++-Igloo/makefile
+++ b/languages/C++-Igloo/makefile
@@ -4,9 +4,12 @@ HPP_FILES = $(wildcard *.hpp)
 COMPILED_HPP_FILES = $(patsubst %.hpp,%.compiled_hpp,$(HPP_FILES))
 CPP_FILES = $(wildcard *.cpp)
 
+.PHONY: test.output
+test.output: test makefile
+	./$<
+
 test: makefile $(CPP_FILES) $(COMPILED_HPP_FILES)
 	@$(CXX) -I. $(CXXFLAGS) -O $(CPP_FILES) -o $@
-	@./$@
 
 # This rule ensures header files build in their own right.
 # The quality of header files is important because header files

--- a/languages/C++-assert/makefile
+++ b/languages/C++-assert/makefile
@@ -4,9 +4,12 @@ HPP_FILES = $(wildcard *.hpp)
 COMPILED_HPP_FILES = $(patsubst %.hpp,%.compiled_hpp,$(HPP_FILES))
 CPP_FILES = $(wildcard *.cpp)
 
+.PHONY: test.output
+test.output: test makefile
+	./$<
+
 test: makefile $(CPP_FILES) $(COMPILED_HPP_FILES)
 	@$(CXX) -I. $(CXXFLAGS) -O $(CPP_FILES) -o $@
-	@./$@
 
 # This rule ensures header files build in their own right.
 # The quality of header files is important because header files


### PR DESCRIPTION
I was playing with the Boost.Test language that I added and got a timeout. Running the tests again I just got a message from make that everything was up to date. The same thing happened when ever you ran the tests without making any changes. I've fixed this for Boost.Test and the other C++ test frameworks that used similar makefiles.