### PR TITLE
Ensure that nothing gets hidden behind the footer

### DIFF
--- a/app/assets/stylesheets/cyber-dojo.css.scss
+++ b/app/assets/stylesheets/cyber-dojo.css.scss
@@ -5,6 +5,8 @@ table { border-spacing: 0; }
   font-size: 0.9em;
   margin: { top: 0.3em; left: 0.3em; }
   color: $lighter-color;
+  // ensure that nothing gets hidden by the footer
+  padding-bottom: 32px;
 }
 
 body {


### PR DESCRIPTION
I noticed that I was loosing a bit of cyber-dojo at the bottom of the screen behind the footer. Here's a little tweak to the css that should prevent this.