### PR TITLE
Fixed docker_pull_all.rb to use the new manifest files location

### DIFF
--- a/admin_scripts/docker_pull_all.rb
+++ b/admin_scripts/docker_pull_all.rb
@@ -5,7 +5,7 @@ require 'json'
 CYBER_DOJO_ROOT_DIR = '/var/www/cyber-dojo'
 
 image_names = [ ]
-Dir.glob("#{CYBER_DOJO_ROOT_DIR}/languages/*/manifest.json") do |file|
+Dir.glob("#{CYBER_DOJO_ROOT_DIR}/languages/*/*/manifest.json") do |file|
   json = JSON.parse(IO.read(file))
   image_name = json['image_name']
   image_names << image_name if !image_name.nil?


### PR DESCRIPTION
The languages manifest.json files have been moved to a directory format
of "languages/<language>/<test framework>/manifest.json". This updates
the "admin_scripts/docker_pull_all.rb" script to match the new locations