### PR TITLE
Support for Atom package 'cyber-dojo' REST Requests

### DIFF
--- a/app/controllers/kata_controller.rb
+++ b/app/controllers/kata_controller.rb
@@ -13,6 +13,15 @@ class KataController < ApplicationController
     @title = 'test:' + @kata.id[0..5] + ':' + @avatar.name
   end
 
+  def show_json
+    render :json => {
+      'visible_files' => avatar.visible_files,
+      'avatar' => avatar.name,
+      'csrf_token' => form_authenticity_token,
+      'lights' => avatar.lights.map { |light| light.to_json }
+    }
+  end
+
   def run_tests
     @kata   = kata
     @avatar = avatar
@@ -39,9 +48,10 @@ class KataController < ApplicationController
     #  :seconds_since_last_test => seconds_since_last_test(avatar,tag)
     #}
     #one_self.tested(@avatar,hash)
-      
+
     respond_to do |format|
       format.js { render layout: false }
+      format.json { show_json }
     end
   end
 
@@ -84,5 +94,5 @@ private
   def seconds_since_last_test(avatar,tag)
     (avatar.tags[tag].time - avatar.tags[tag-1].time).to_i
   end
-  
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 
 CyberDojo::Application.routes.draw do
-  
+
   # The priority is based upon order of creation:
   # first created -> highest priority.
 
@@ -23,13 +23,14 @@ CyberDojo::Application.routes.draw do
     get 're_enter'    => :re_enter, :constraints => { :format => :json }
   end
 
-  scope path: '/setup', controller: :setup do    
+  scope path: '/setup', controller: :setup do
     get 'show(/:id)' => :show
     get 'save' => :save, :constraints => { :format => :json }
   end
 
   scope path: '/kata', controller: :kata do
     get  'edit(/:id)'      => :edit
+    get  'show_json(/:id)' => :show_json
     post 'run_tests(/:id)' => :run_tests
   end
 


### PR DESCRIPTION
Added route to kata_controller to get the kata state for an avatar as json result and to run_tests and return the state as json result as well. This modification is needed for an Atom package 'cyber-dojo' with that it is possible to code against cyber-dojo using the Atom editor.

The Atom package makes it possible to edit a Kata within the Atom editor. The Atom editor package will be published soon:
https://github.com/klaas1979/atom-cyber-dojo

Use atom and install the 'cyber-dojo' package.