### PR TITLE
Created new javascript container with 0.12.7 + jasmine 2.3

### DIFF
--- a/app/lib/OutputColour.rb
+++ b/app/lib/OutputColour.rb
@@ -144,7 +144,7 @@ module OutputColour # mix-in
     return :green if /test result: ok/.match(output)
     return :amber
   end
-  
+
   def self.parse_go_testing(output)
     return :amber if /FAIL(\s*)_\/sandbox \[build failed\]/.match(output)
     return :red   if /FAIL/.match(output)
@@ -229,6 +229,15 @@ module OutputColour # mix-in
     jasmine_pattern = /(\d+) tests?, (\d+) assertions?, (\d+) failures?/
     if match = jasmine_pattern.match(output)
       match[3] === '0' ? :green : :red
+    else
+      :amber
+    end
+  end
+
+  def self.parse_jasmine2_3(output)
+    jasmine_pattern = /(\d+) specs?, (\d+) failures?/
+    if match = jasmine_pattern.match(output)
+      match[2] === '0' ? :green : :red
     else
       :amber
     end

--- a/languages/Javascript0.12.7/Dockerfile
+++ b/languages/Javascript0.12.7/Dockerfile
@@ -1,0 +1,9 @@
+FROM      debian:wheezy
+MAINTAINER Klaas Reineke <klaas.reineke@gmail.com>
+
+RUN apt-get update
+RUN apt-get install --yes curl
+RUN curl --silent --location https://deb.nodesource.com/setup_0.12 | bash -
+RUN apt-get install --yes nodejs
+
+RUN apt-get install -y npm

--- a/languages/Javascript0.12.7/build-docker-container.sh
+++ b/languages/Javascript0.12.7/build-docker-container.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t cyberdojo/javascript-0.12.7  .

--- a/languages/Javascript0.12.7/jasmine2.3/Dockerfile
+++ b/languages/Javascript0.12.7/jasmine2.3/Dockerfile
@@ -1,0 +1,5 @@
+FROM       cyberdojo/javascript-0.12.7
+MAINTAINER Klaas Reineke <klaas.reineke@gmail.com>
+
+RUN npm install -g jasmine
+

--- a/languages/Javascript0.12.7/jasmine2.3/build-docker-container.sh
+++ b/languages/Javascript0.12.7/jasmine2.3/build-docker-container.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t cyberdojo/javascript-0.12.7_jasmine-2.3  .

--- a/languages/Javascript0.12.7/jasmine2.3/cyber-dojo.sh
+++ b/languages/Javascript0.12.7/jasmine2.3/cyber-dojo.sh
@@ -1,0 +1,1 @@
+jasmine JASMINE_CONFIG_PATH=./jasmine.json

--- a/languages/Javascript0.12.7/jasmine2.3/hiker-spec.js
+++ b/languages/Javascript0.12.7/jasmine2.3/hiker-spec.js
@@ -1,0 +1,8 @@
+
+require('./hiker.js');
+
+describe("answer", function() {
+  it("to life the universe and everything", function() {
+    expect(answer()).toEqual(42);
+  });
+});

--- a/languages/Javascript0.12.7/jasmine2.3/hiker.js
+++ b/languages/Javascript0.12.7/jasmine2.3/hiker.js
@@ -1,0 +1,4 @@
+
+answer = function() {
+  return 6 * 9;
+};

--- a/languages/Javascript0.12.7/jasmine2.3/jasmine.json
+++ b/languages/Javascript0.12.7/jasmine2.3/jasmine.json
@@ -1,0 +1,9 @@
+{
+    "spec_dir": ".",
+    "spec_files": [
+        "*[sS]pec.js"
+    ],
+    "helpers": [
+        "*helper.js"
+    ]
+}

--- a/languages/Javascript0.12.7/jasmine2.3/manifest.json
+++ b/languages/Javascript0.12.7/jasmine2.3/manifest.json
@@ -1,0 +1,17 @@
+{
+  "visible_filenames": [
+    "hiker-spec.js",
+    "hiker.js",
+    "cyber-dojo.sh",
+    "jasmine.json"
+  ],
+  "progress_regexs": [
+    "/(\d+) specs?, ([1-9]\d*) failures?/",
+    "/(\d+) specs?, (0) failures?/"
+  ],
+  "filename_extension": ".js",
+  "unit_test_framework": "jasmine2_3",
+  "display_name": "Javascript, jasmine2.3",
+  "image_name": "cyberdojo/javascript-0.12.7_jasmine-2.3",
+  "tab_size": 2
+}


### PR DESCRIPTION
Hi Jon,

I added a new Directory with the new 0.12.7 version of javascript and the new 2.3 version of jasmine. Jasmines syntax evolved, so that it is useful to have the new syntax available in dojos.

I needed to extend the OutputColour.rb to parse the new syntax of jasmine.

I found two gotchas on my way:
I cannot create a Docker container that does not start with your "cyberdojo" repository name. Because you test on language.runnable? and somewhere down the road .startWith('cyberdojo')
This is the reason to include the Dockerfile definitions within this pull request. Maybe you would like to change the javascript folder name etc. It would be great if you can build them again and publish them to your repository. By the way they are based on a debian wheezy image, maybe this does not fit your structure.

The regexes to parse the result that I can add to the manifest should be used for the lights.colour. Then it is possible to add a new container without extending the OutputColour.rb class.

Regards Klaas