### PR TITLE
Catch exceptions thrown by starting a process that does not exist

### DIFF
--- a/lib/BackgroundProcess.rb
+++ b/lib/BackgroundProcess.rb
@@ -5,6 +5,9 @@ require 'open4'
 
 class BackgroundProcess
   def start(cmd)
-    Open4::popen4(cmd)
+    begin
+      Open4::popen4(cmd)
+    rescue
+    end
   end
 end

--- a/test/lib/background_process_test.rb
+++ b/test/lib/background_process_test.rb
@@ -17,4 +17,11 @@ class CurlOneSelfTests < LibTestBase
     assert run_time < 1000, "Starting the background process took longer than 1 second to complete"
   end
 
+  test '4e78b26f',
+  'Starting a background process that does not exist does not crash the host process' do
+    background_process = BackgroundProcess.new
+
+    background_process.start("this-does-not-exist")
+  end
+
 end


### PR DESCRIPTION
Stop exceptions propagating when starting a background process that does not exist.