### PR TITLE
Reverted to not use classes in Javascript examples

### DIFF
--- a/languages/Javascript/assert/hiker.js
+++ b/languages/Javascript/assert/hiker.js
@@ -1,8 +1,7 @@
 'use strict';
 
-module.exports =
-class Hiker {
-  answer() {
-    return 6 * 9;
-  }
-};
+module.exports = answer;
+
+function answer() {
+  return 6 * 9;
+}

--- a/languages/Javascript/assert/hikerTest.js
+++ b/languages/Javascript/assert/hikerTest.js
@@ -1,8 +1,8 @@
 'use strict';
 
-let Hiker  = require('./hiker.js');
+let answer  = require('./hiker.js');
 let assert = require('assert');
 
-assert.equal(new Hiker().answer(), 42 );
+assert.equal(answer(), 42 );
 
 console.log('All tests passed');

--- a/languages/Javascript/jasmine/hiker-spec.js
+++ b/languages/Javascript/jasmine/hiker-spec.js
@@ -1,10 +1,9 @@
 'use strict';
 
-let Hiker = require('./hiker.js');
+let answer = require('./hiker.js');
 
 describe("answer", function() {
   it("to life the universe and everything", function() {
-    let hiker = new Hiker();
-    expect(hiker.answer()).toEqual(42);
+    expect(answer()).toEqual(42);
   });
 });

--- a/languages/Javascript/jasmine/hiker.js
+++ b/languages/Javascript/jasmine/hiker.js
@@ -1,10 +1,7 @@
 'use strict';
 
-module.exports =
-class Hiker {
-  constructor() {}
+module.exports = answer;
 
-  answer() {
-    return 6 * 9;
-  }
-};
+function answer() {
+  return 6 * 9;
+}

--- a/languages/Javascript/mocha_chai_sinon/hiker.js
+++ b/languages/Javascript/mocha_chai_sinon/hiker.js
@@ -1,10 +1,7 @@
 'use strict';
 
-module.exports =
-class Hiker {
-  constructor() {}
+module.exports = answer;
 
-  answer() {
-    return 6 * 9;
-  }
-};
+function answer() {
+  return 6 * 9;
+}

--- a/languages/Javascript/mocha_chai_sinon/hikerTest.js
+++ b/languages/Javascript/mocha_chai_sinon/hikerTest.js
@@ -1,9 +1,9 @@
 'use strict';
 
-let Hiker = require('./hiker.js');
+let answer = require('./hiker.js');
 
 describe('Should Style: Answer', function () {
   it('to life the universe and everything', function () {
-    new Hiker().answer().should.equal(42);
+    answer().should.equal(42);
   });
 });

--- a/languages/Javascript/qunit_sinon/hiker-test.js
+++ b/languages/Javascript/qunit_sinon/hiker-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-let Hiker = require('./hiker.js');
+let answer = require('./hiker.js');
 
 test("answer", function() {
-    equal(new Hiker().answer(), 42, "to life the universe and everything");
+    equal(answer(), 42, "to life the universe and everything");
 });

--- a/languages/Javascript/qunit_sinon/hiker.js
+++ b/languages/Javascript/qunit_sinon/hiker.js
@@ -1,10 +1,7 @@
 'use strict';
 
-module.exports =
-class Hiker {
-  constructor() {}
+module.exports = answer;
 
-  answer() {
-    return 6 * 9;
-  }
-};
+function answer() {
+  return 6 * 9;
+}


### PR DESCRIPTION
Hi Jon,

as discussed. I removed the class keyword and reverted to simple functions. I did not ask Magnus for a reply, but either way the classes should not be in there. I tested it locally and it worked.

Regards Klaas