### PR TITLE
Fix to allow Fs to be entered in the kata ID on the enter page

### DIFF
--- a/app/views/enter/_enter_id.html.erb
+++ b/app/views/enter/_enter_id.html.erb
@@ -28,7 +28,7 @@ $(function() {
   // Only accept hex input
   kataIdInput.keypress(function(e) {
     var str = String.fromCharCode(!e.charCode ? e.which : e.charCode);
-    if (str.match(/[a-eA-E0-9]/)) { return true; }
+    if (str.match(/[a-fA-F0-9]/)) { return true; }
     e.preventDefault();
     return false;
   });


### PR DESCRIPTION
Are there tests for this that I should change as well? If there are where do they live?

This caught me out on my server, it doesn't appear to be live on the main cyber-dojo server.