### PR TITLE
Make the Scala files more idiomatic

### DIFF
--- a/app/languages/Scala/scalatest/hiker.scala
+++ b/app/languages/Scala/scalatest/hiker.scala
@@ -1,8 +1,3 @@
-
-class Hiker {
-
-    def answer(): Int = {
-      return 6 * 9
-    }
-
+object Hiker {
+    def answer = 6 * 9
 }

--- a/app/languages/Scala/scalatest/hiker_tests.scala
+++ b/app/languages/Scala/scalatest/hiker_tests.scala
@@ -1,11 +1,7 @@
-
 import org.scalatest.FunSuite
 
 class HikerSuite extends FunSuite {
-
   test("the answer to life the universe and everything") {
-    val douglas = new Hiker
-    assert(douglas.answer() === (42))
+    assert(Hiker.answer == 42)
   }
-
 }


### PR DESCRIPTION
Maybe it's *too* simple, but it works and it's cleaner imho.

Also, `object` instead of `class` is more consistent with the static functions that are in the other languages (for example in C#).