### PR TITLE
remove redundant install of build-essential from javascript Dockerfile

### DIFF
--- a/app/languages/Javascript/_docker_context/Dockerfile
+++ b/app/languages/Javascript/_docker_context/Dockerfile
@@ -18,5 +18,3 @@ RUN n 4.2.1
 
 RUN chmod -R a+w /usr/local
 
-RUN apt-get update && apt-get install --yes \
-  build-essential


### PR DESCRIPTION
since the base build-essential image has it already. 
not sure if this explains what I saw when pulling js derived images, the sizes were bigger than expected.